### PR TITLE
Report temp location on compilation error

### DIFF
--- a/artist/plot.py
+++ b/artist/plot.py
@@ -152,7 +152,8 @@ class BasePlotContainer(object):
             error_lines = [line for line in output_lines
                            if line and line[0] == '!']
             errors = '\n'.join(error_lines)
-            raise RuntimeError("LaTeX compilation failed:\n" + errors)
+            raise RuntimeError("LaTeX compilation failed:\n" + errors +
+                               "\nTemp build dir: " + dir_path)
         finally:
             os.chdir(cwd)
 


### PR DESCRIPTION
I found this useful because I could look in the tex to try to find the bug.
Of course the compilation should normally not fail and the users should not have to deal with this.
But while developing new functionallity I found this useful..