### PR TITLE
Fancy scattering

### DIFF
--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -51,6 +51,7 @@ class MultiPlot(BasePlotContainer):
         self.limits = {'xmin': None, 'xmax': None,
                        'ymin': None, 'ymax': None}
         self.ticks = {'x': [], 'y': []}
+        self.colormap = None
 
         self.subplots = []
         for i in range(rows):
@@ -395,6 +396,7 @@ class MultiPlot(BasePlotContainer):
                                    width=self.width, height=self.height,
                                    xlabel=self.xlabel, ylabel=self.ylabel,
                                    limits=self.limits, ticks=self.ticks,
+                                   colormap=self.colormap,
                                    subplots=self.subplots,
                                    plot_template=self.template)
         return response
@@ -434,6 +436,15 @@ class MultiPlot(BasePlotContainer):
         """
         subplot = self.get_subplot_at(row, column)
         subplot.set_ylabel(text)
+
+    def set_colormap(self, name):
+        """Choose a colormap for all subplots.
+
+        :param name: name of the colormap to use. (e.g. hot, cool, blackwhite,
+                     greenyellow). If None a coolwarm colormap is used.
+
+        """
+        self.colormap = name
 
 
 class SubPlotContainer(SubPlot):

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -265,7 +265,7 @@ class MultiPlot(BasePlotContainer):
         subplot.set_mlimits(min, max)
 
     def set_mlimits_for_all(self, row_column_list=None, min=None, max=None):
-        """Set y-axis limits of specified subplots.
+        """Set limits for point meta (colormap) for specified subplots.
 
         :param row_column_list: a list containing (row, column) tuples to
             specify the subplots, or None to indicate *all* subplots.
@@ -282,23 +282,23 @@ class MultiPlot(BasePlotContainer):
                 self.set_mlimits(row, column, min, max)
 
     def set_slimits(self, row, column, min, max):
-        """Set limits for the point meta (colormap).
+        """Set limits for the point sizes.
 
-        :param min: value for start of the colormap.
-        :param max: value for end of the colormap.
+        :param min: point size for the lowest value.
+        :param max: point size for the highest value.
 
         """
         subplot = self.get_subplot_at(row, column)
         subplot.set_slimits(min, max)
 
     def set_slimits_for_all(self, row_column_list=None, min=None, max=None):
-        """Set y-axis limits of specified subplots.
+        """Set point size limits of specified subplots.
 
         :param row_column_list: a list containing (row, column) tuples to
             specify the subplots, or None to indicate *all* subplots.
         :type row_column_list: list or None
-        :param min: value for start of the colormap.
-        :param max: value for end of the colormap.
+        :param min: point size for the lowest value.
+        :param max: point size for the highest value.
 
         """
         if min is None or max is None:

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -80,7 +80,7 @@ class MultiPlot(BasePlotContainer):
     def set_empty(self, row, column):
         """Keep one of the subplots completely empty.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
 
         """
         subplot = self.get_subplot_at(row, column)
@@ -100,7 +100,7 @@ class MultiPlot(BasePlotContainer):
     def set_title(self, row, column, text):
         """Set a title text.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param text: title text.
 
         """
@@ -111,7 +111,7 @@ class MultiPlot(BasePlotContainer):
                   style=None):
         """Set a label for the subplot.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param text: the label text.
         :param location: the location of the label inside the plot.  May
             be one of 'center', 'upper right', 'lower right', 'upper
@@ -125,7 +125,7 @@ class MultiPlot(BasePlotContainer):
     def show_xticklabels(self, row, column):
         """Show the x-axis tick labels for a subplot.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
 
         """
         subplot = self.get_subplot_at(row, column)
@@ -149,7 +149,7 @@ class MultiPlot(BasePlotContainer):
     def show_yticklabels(self, row, column):
         """Show the y-axis tick labels for a subplot.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
 
         """
         subplot = self.get_subplot_at(row, column)
@@ -177,7 +177,7 @@ class MultiPlot(BasePlotContainer):
         row.  This can be used to e.g. alternatively draw the tick labels
         on the bottom or the top of the subplot.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param position: 'top' or 'bottom' to specify the position of the
             tick labels.
 
@@ -192,7 +192,7 @@ class MultiPlot(BasePlotContainer):
         column.  This can be used to e.g. alternatively draw the tick
         labels on the left or the right of the subplot.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param position: 'left' or 'right' to specify the position of the
             tick labels.
 
@@ -203,7 +203,7 @@ class MultiPlot(BasePlotContainer):
     def set_xlimits(self, row, column, min=None, max=None):
         """Set x-axis limits of a subplot.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param min: minimal axis value
         :param max: maximum axis value
 
@@ -231,7 +231,7 @@ class MultiPlot(BasePlotContainer):
     def set_ylimits(self, row, column, min=None, max=None):
         """Set y-axis limits of a subplot.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param min: minimal axis value
         :param max: maximum axis value
 
@@ -317,7 +317,7 @@ class MultiPlot(BasePlotContainer):
     def set_xticks(self, row, column, ticks):
         """Manually specify the x-axis tick values.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param ticks: list of tick values.
 
         """
@@ -342,7 +342,7 @@ class MultiPlot(BasePlotContainer):
     def set_logxticks(self, row, column, logticks):
         """Manually specify the x-axis log tick values.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param logticks: logarithm of the locations for the ticks along the
             axis.
 
@@ -375,7 +375,7 @@ class MultiPlot(BasePlotContainer):
     def set_yticks(self, row, column, ticks):
         """Manually specify the y-axis tick values.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param ticks: list of tick values.
 
         """
@@ -400,7 +400,7 @@ class MultiPlot(BasePlotContainer):
     def set_logyticks(self, row, column, logticks):
         """Manually specify the y-axis log tick values.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param logticks: logarithm of the locations for the ticks along the
             axis.
 
@@ -433,7 +433,7 @@ class MultiPlot(BasePlotContainer):
     def get_subplot_at(self, row, column):
         """Return the subplot at row, column position.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
 
         """
         idx = row * self.columns + column
@@ -484,7 +484,7 @@ class MultiPlot(BasePlotContainer):
     def set_subplot_xlabel(self, row, column, text):
         """Set a label for the x-axis of a subplot.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param text: text of the label.
 
         """
@@ -494,7 +494,7 @@ class MultiPlot(BasePlotContainer):
     def set_subplot_ylabel(self, row, column, text):
         """Set a label for the y-axis of a subplot.
 
-        :param row, column: specify the subplot.
+        :param row,column: specify the subplot.
         :param text: text of the label.
 
         """

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -523,6 +523,10 @@ class MultiPlot(BasePlotContainer):
     def set_colorbar(self, label='', horizontal=False):
         """Show the colorbar, it will be attached to the last plot.
 
+        Not for the histogram2d, only for the scatter_table.
+        Global mlimits should be set for this to properly reflect the
+        colormap of each subplot.
+
         :param label: axis label for the colorbar.
         :param horizontal: boolean, if True the colobar will be horizontal.
 

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -11,11 +11,13 @@ Contents
 
 """
 
-import jinja2
 import tempfile
 import os
 import subprocess
 import shutil
+from math import sqrt
+
+import jinja2
 
 from plot import BasePlotContainer, SubPlot
 
@@ -304,8 +306,8 @@ class MultiPlot(BasePlotContainer):
         if min is None or max is None:
             raise Exception('Both min and max are required.')
         if row_column_list is None:
-            self.limits['smin'] = min
-            self.limits['smax'] = max
+            self.limits['smin'] = sqrt(min)
+            self.limits['smax'] = sqrt(max)
         else:
             for row, column in row_column_list:
                 self.set_slimits(row, column, min, max)

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -49,7 +49,9 @@ class MultiPlot(BasePlotContainer):
         self.xlabel = None
         self.ylabel = None
         self.limits = {'xmin': None, 'xmax': None,
-                       'ymin': None, 'ymax': None}
+                       'ymin': None, 'ymax': None,
+                       'mmin': None, 'mmax': None,
+                       'smin': None, 'smax': None}
         self.ticks = {'x': [], 'y': []}
         self.colormap = None
 
@@ -243,7 +245,6 @@ class MultiPlot(BasePlotContainer):
         :param max: maximum axis value
 
         """
-
         if row_column_list is None:
             self.limits['ymin'] = min
             self.limits['ymax'] = max
@@ -273,13 +274,41 @@ class MultiPlot(BasePlotContainer):
         :param max: value for end of the colormap.
 
         """
-
         if row_column_list is None:
             self.limits['mmin'] = min
             self.limits['mmax'] = max
         else:
             for row, column in row_column_list:
                 self.set_mlimits(row, column, min, max)
+
+    def set_slimits(self, row, column, min, max):
+        """Set limits for the point meta (colormap).
+
+        :param min: value for start of the colormap.
+        :param max: value for end of the colormap.
+
+        """
+        subplot = self.get_subplot_at(row, column)
+        subplot.set_slimits(min, max)
+
+    def set_slimits_for_all(self, row_column_list=None, min=None, max=None):
+        """Set y-axis limits of specified subplots.
+
+        :param row_column_list: a list containing (row, column) tuples to
+            specify the subplots, or None to indicate *all* subplots.
+        :type row_column_list: list or None
+        :param min: value for start of the colormap.
+        :param max: value for end of the colormap.
+
+        """
+        if min is None or max is None:
+            raise Exception('Both min and max are required.')
+        if row_column_list is None:
+            self.limits['smin'] = min
+            self.limits['smax'] = max
+        else:
+            for row, column in row_column_list:
+                self.set_slimits(row, column, min, max)
 
     def set_xticks(self, row, column, ticks):
         """Manually specify the x-axis tick values.

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -251,6 +251,36 @@ class MultiPlot(BasePlotContainer):
             for row, column in row_column_list:
                 self.set_ylimits(row, column, min, max)
 
+    def set_mlimits(self, row, column, min=None, max=None):
+        """Set limits for the point meta (colormap).
+
+        Point meta values outside this range will be clipped.
+
+        :param min: value for start of the colormap.
+        :param max: value for end of the colormap.
+
+        """
+        subplot = self.get_subplot_at(row, column)
+        subplot.set_mlimits(min, max)
+
+    def set_mlimits_for_all(self, row_column_list=None, min=None, max=None):
+        """Set y-axis limits of specified subplots.
+
+        :param row_column_list: a list containing (row, column) tuples to
+            specify the subplots, or None to indicate *all* subplots.
+        :type row_column_list: list or None
+        :param min: value for start of the colormap.
+        :param max: value for end of the colormap.
+
+        """
+
+        if row_column_list is None:
+            self.limits['mmin'] = min
+            self.limits['mmax'] = max
+        else:
+            for row, column in row_column_list:
+                self.set_mlimits(row, column, min, max)
+
     def set_xticks(self, row, column, ticks):
         """Manually specify the x-axis tick values.
 

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -16,6 +16,7 @@ import os
 import subprocess
 import shutil
 from math import sqrt
+import warnings
 
 import jinja2
 
@@ -55,6 +56,7 @@ class MultiPlot(BasePlotContainer):
                        'mmin': None, 'mmax': None,
                        'smin': None, 'smax': None}
         self.ticks = {'x': [], 'y': []}
+        self.colorbar = None
         self.colormap = None
 
         self.subplots = []
@@ -312,25 +314,6 @@ class MultiPlot(BasePlotContainer):
             for row, column in row_column_list:
                 self.set_slimits(row, column, min, max)
 
-    def set_scalebar_for_all(self, row_column_list=None,
-                             location='lower right'):
-        """Show marker area scale for subplots.
-
-        :param row_column_list: a list containing (row, column) tuples to
-            specify the subplots, or None to indicate *all* subplots.
-        :param location: the location of the label inside the plot.  May
-            be one of 'center', 'upper right', 'lower right', 'upper
-            left', 'lower left'.
-
-        """
-        if row_column_list is None:
-            for subplot in self.subplots:
-                subplot.set_scalebar(location)
-        else:
-            for row, column in row_column_list:
-                subplot = self.get_subplot_at(row, column)
-                subplot.set_scalebar(location)
-
     def set_xticks(self, row, column, ticks):
         """Manually specify the x-axis tick values.
 
@@ -476,6 +459,7 @@ class MultiPlot(BasePlotContainer):
                                    width=self.width, height=self.height,
                                    xlabel=self.xlabel, ylabel=self.ylabel,
                                    limits=self.limits, ticks=self.ticks,
+                                   colorbar=self.colorbar,
                                    colormap=self.colormap,
                                    subplots=self.subplots,
                                    plot_template=self.template)
@@ -516,6 +500,38 @@ class MultiPlot(BasePlotContainer):
         """
         subplot = self.get_subplot_at(row, column)
         subplot.set_ylabel(text)
+
+    def set_scalebar_for_all(self, row_column_list=None,
+                             location='lower right'):
+        """Show marker area scale for subplots.
+
+        :param row_column_list: a list containing (row, column) tuples to
+            specify the subplots, or None to indicate *all* subplots.
+        :param location: the location of the label inside the plot.  May
+            be one of 'center', 'upper right', 'lower right', 'upper
+            left', 'lower left'.
+
+        """
+        if row_column_list is None:
+            for subplot in self.subplots:
+                subplot.set_scalebar(location)
+        else:
+            for row, column in row_column_list:
+                subplot = self.get_subplot_at(row, column)
+                subplot.set_scalebar(location)
+
+    def set_colorbar(self, label='', horizontal=False):
+        """Show the colorbar, it will be attached to the last plot.
+
+        :param label: axis label for the colorbar.
+        :param horizontal: boolean, if True the colobar will be horizontal.
+
+        """
+        if self.limits['mmin'] is None or self.limits['mmax'] is None:
+            warnings.warn('Set (only) global point meta limits to ensure the '
+                          'colorbar is correct for all subplots.')
+        self.colorbar = {'label': label,
+                         'horizontal': horizontal}
 
     def set_colormap(self, name):
         """Choose a colormap for all subplots.

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -312,6 +312,25 @@ class MultiPlot(BasePlotContainer):
             for row, column in row_column_list:
                 self.set_slimits(row, column, min, max)
 
+    def set_scalebar_for_all(self, row_column_list=None,
+                             location='lower right'):
+        """Show marker area scale for subplots.
+
+        :param row_column_list: a list containing (row, column) tuples to
+            specify the subplots, or None to indicate *all* subplots.
+        :param location: the location of the label inside the plot.  May
+            be one of 'center', 'upper right', 'lower right', 'upper
+            left', 'lower left'.
+
+        """
+        if row_column_list is None:
+            for subplot in self.subplots:
+                subplot.set_scalebar(location)
+        else:
+            for row, column in row_column_list:
+                subplot = self.get_subplot_at(row, column)
+                subplot.set_scalebar(location)
+
     def set_xticks(self, row, column, ticks):
         """Manually specify the x-axis tick values.
 

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -207,6 +207,7 @@ class SubPlot(object):
     def __init__(self):
         self.shaded_regions_list = []
         self.plot_series_list = []
+        self.plot_table_list = []
         self.histogram2d_list = []
         self.bitmap_list = []
         self.pin_list = []
@@ -223,6 +224,8 @@ class SubPlot(object):
                       'xlabels': '', 'ylabels': '',
                       'xsuffix': '', 'ysuffix': ''}
         self.axis_equal = False
+        self.colorbar = False
+        self.colormap = None
 
     def save_assets(self, dest_path, suffix=''):
         """Save plot assets alongside dest_path.
@@ -395,6 +398,32 @@ class SubPlot(object):
 
         """
         self.plot(x, y, mark=mark, linestyle=None, markstyle=markstyle)
+
+    def scatter_table(self, x, y, c, s, mark='*'):
+        """Add a data series to the plot.
+
+        :param x: array containing x-values.
+        :param y: array containing y-values.
+        :param c: array containing values for the color of the mark.
+        :param s: array containing values for the size of the mark.
+        :param mark: the symbol used to mark the data point.  May be None,
+            or any plot mark accepted by TikZ (e.g. *, x, +, o, square,
+            triangle).
+
+        The dimensions of x, y, c and s should be equal. The c values will
+        be mapped to a colormap.
+
+        """
+        # clear the background of the marks
+        #self._clear_plot_mark_background(x, y, mark, markstyle)
+        # draw the plot series over the background
+        options = self._parse_plot_options(mark)
+        plot_series = self._create_plot_tables_object(x, y, c, s, options)
+        self.plot_table_list.append(plot_series)
+
+    def _create_plot_tables_object(self, x, y, c, s, options=None):
+        return {'options': options,
+                'data': list(izip_longest(x, y, c, s))}
 
     def set_title(self, text):
         """Set a title text."""
@@ -679,6 +708,20 @@ class SubPlot(object):
 
         self.axis_equal = True
 
+    def set_colorbar(self, label=''):
+        """Show the colorbar."""
+
+        self.colorbar = {'label': label}
+
+    def set_colormap(self, name):
+        """Choose a colormap for :meth:`scatter_table`.
+
+        :param name: name of the colormap to use. (e.g. hot, cool, blackwhite,
+                     greenyellow). If None a coolwarm colormap is used.
+
+        """
+        self.colormap = name
+
     def _parse_plot_options(self, mark=None, linestyle=None,
                             use_steps=False, markstyle=None):
         options = []
@@ -826,6 +869,8 @@ class Plot(SubPlot, BasePlotContainer):
             limits=self.limits,
             ticks=self.ticks,
             axis_equal=self.axis_equal,
+            colorbar=self.colorbar,
+            colormap=self.colormap,
             plot=self,
             plot_template=self.template)
         return response

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -740,7 +740,7 @@ class SubPlot(object):
 
         self.axis_equal = True
 
-    def set_scalebar(self, location='upper right'):
+    def set_scalebar(self, location='lower right'):
         """Show marker area scale
 
         :param location: the location of the label inside the plot.  May

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -754,10 +754,15 @@ class SubPlot(object):
         else:
             raise RuntimeError("Unknown scalebar location: %s" % location)
 
-    def set_colorbar(self, label=''):
-        """Show the colorbar."""
+    def set_colorbar(self, label='', horizontal=False):
+        """Show the colorbar.
 
-        self.colorbar = {'label': label}
+        :param label: axis label for the colorbar.
+        :param horizontal: boolean, if True the colobar will be horizontal.
+
+        """
+        self.colorbar = {'label': label,
+                         'horizontal': horizontal}
 
     def set_colormap(self, name):
         """Choose a colormap for :meth:`scatter_table`.

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -22,11 +22,11 @@ import os
 import tempfile
 import shutil
 from itertools import izip_longest
+from math import log10, sqrt
 
 from PIL import Image
 import jinja2
 import numpy as np
-from math import log10
 
 
 RELATIVE_NODE_LOCATIONS = {'upper right': {'node_location': 'below left',
@@ -420,6 +420,7 @@ class SubPlot(object):
         #self._clear_plot_mark_background(x, y, mark, markstyle)
         # draw the plot series over the background
         options = self._parse_plot_options(mark)
+        s = [sqrt(si) for si in s]
         plot_series = self._create_plot_tables_object(x, y, c, s, options)
         self.plot_table_list.append(plot_series)
 
@@ -638,8 +639,8 @@ class SubPlot(object):
         :param max: point size for the highest value.
 
         """
-        self.limits['smin'] = min
-        self.limits['smax'] = max
+        self.limits['smin'] = sqrt(min)
+        self.limits['smax'] = sqrt(max)
 
     def set_xticks(self, ticks):
         """Set ticks for the x-axis.

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -220,7 +220,8 @@ class SubPlot(object):
         self.label = None
         self.limits = {'xmin': None, 'xmax': None,
                        'ymin': None, 'ymax': None,
-                       'mmin': None, 'mmax': None}
+                       'mmin': None, 'mmax': None,
+                       'smin': None, 'smax': None}
         self.ticks = {'x': [], 'y': [],
                       'xlabels': '', 'ylabels': '',
                       'xsuffix': '', 'ysuffix': ''}
@@ -424,7 +425,9 @@ class SubPlot(object):
 
     def _create_plot_tables_object(self, x, y, c, s, options=None):
         return {'options': options,
-                'data': list(izip_longest(x, y, c, s))}
+                'data': list(izip_longest(x, y, c, s)),
+                'smin': min(s),
+                'smax': max(s)}
 
     def set_title(self, text):
         """Set a title text."""
@@ -625,6 +628,18 @@ class SubPlot(object):
         """
         self.limits['mmin'] = min
         self.limits['mmax'] = max
+
+    def set_slimits(self, min, max):
+        """Set limits for the size of points in :meth:`scatter_table`.
+
+        If both are None, the size will be the given values.
+
+        :param min: point size for the lowest value.
+        :param max: point size for the highest value.
+
+        """
+        self.limits['smin'] = min
+        self.limits['smax'] = max
 
     def set_xticks(self, ticks):
         """Set ticks for the x-axis.

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -757,6 +757,8 @@ class SubPlot(object):
     def set_colorbar(self, label='', horizontal=False):
         """Show the colorbar.
 
+        Not for the histogram2d, only for the scatter_table.
+
         :param label: axis label for the colorbar.
         :param horizontal: boolean, if True the colobar will be horizontal.
 

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -226,6 +226,7 @@ class SubPlot(object):
                       'xlabels': '', 'ylabels': '',
                       'xsuffix': '', 'ysuffix': ''}
         self.axis_equal = False
+        self.scalebar = None
         self.colorbar = False
         self.colormap = None
 
@@ -739,6 +740,20 @@ class SubPlot(object):
 
         self.axis_equal = True
 
+    def set_scalebar(self, location='upper right'):
+        """Show marker area scale
+
+        :param location: the location of the label inside the plot.  May
+            be one of 'center', 'upper right', 'lower right', 'upper
+            left', 'lower left'.
+
+        """
+        if location in RELATIVE_NODE_LOCATIONS:
+            scalebar = RELATIVE_NODE_LOCATIONS[location].copy()
+            self.scalebar = scalebar
+        else:
+            raise RuntimeError("Unknown scalebar location: %s" % location)
+
     def set_colorbar(self, label=''):
         """Show the colorbar."""
 
@@ -900,6 +915,7 @@ class Plot(SubPlot, BasePlotContainer):
             limits=self.limits,
             ticks=self.ticks,
             axis_equal=self.axis_equal,
+            scalebar=self.scalebar,
             colorbar=self.colorbar,
             colormap=self.colormap,
             plot=self,

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -219,7 +219,8 @@ class SubPlot(object):
         self.ylabel = None
         self.label = None
         self.limits = {'xmin': None, 'xmax': None,
-                       'ymin': None, 'ymax': None}
+                       'ymin': None, 'ymax': None,
+                       'mmin': None, 'mmax': None}
         self.ticks = {'x': [], 'y': [],
                       'xlabels': '', 'ylabels': '',
                       'xsuffix': '', 'ysuffix': ''}
@@ -610,6 +611,20 @@ class SubPlot(object):
         """
         self.limits['ymin'] = min
         self.limits['ymax'] = max
+
+    def set_mlimits(self, min=None, max=None):
+        """Set limits for the point meta (colormap).
+
+        Point meta values outside this range will be clipped.
+
+        :param min: value corresponding to the start of the colormap.
+            If None, it will be calculated.
+        :param max: value corresponding to the end of the colormap.
+            If None, it will be calculated.
+
+        """
+        self.limits['mmin'] = min
+        self.limits['mmax'] = max
 
     def set_xticks(self, ticks):
         """Set ticks for the x-axis.

--- a/artist/templates/multi_plot.tex
+++ b/artist/templates/multi_plot.tex
@@ -51,6 +51,20 @@
                     %
                     xtick=\empty, ytick=\empty,
                     scaled ticks=false,
+                    {%- if colormap %}
+                        colormap/{{ colormap }},
+                    {%- else %}
+                        colormap={coolwarm}{
+                            rgb255(0cm)=( 59, 76,192);
+                            rgb255(1cm)=( 98,130,234);
+                            rgb255(2cm)=(141,176,254);
+                            rgb255(3cm)=(184,208,249);
+                            rgb255(4cm)=(221,221,221);
+                            rgb255(5cm)=(245,196,173);
+                            rgb255(6cm)=(244,154,123);
+                            rgb255(7cm)=(222, 96, 77);
+                            rgb255(8cm)=(180,  4, 38)},
+                    {%- endif %}
                 ]
                 {% for subplot in subplots %}
                     {% set plot = subplot %}

--- a/artist/templates/multi_plot.tex
+++ b/artist/templates/multi_plot.tex
@@ -12,9 +12,9 @@
     {\def\defaultwidth{ {{ width }} }}
 %
 {%- if height %}
-\pgfkeysifdefined{/artist/height}
-    {\pgfkeysgetvalue{/artist/height}{\defaultheight}}
-    {\def\defaultheight{ {{ height }} }}
+    \pgfkeysifdefined{/artist/height}
+        {\pgfkeysgetvalue{/artist/height}{\defaultheight}}
+        {\def\defaultheight{ {{ height }} }}
 {%- endif %}
 %
 \begin{sansmath}
@@ -33,7 +33,7 @@
                     ymode={{ ymode }},
                     width=\defaultwidth,
                     {%- if height %}
-                    height=\defaultheight,
+                        height=\defaultheight,
                     {%- endif %}
                     %
                     xmin={ {{ limits.xmin }} },

--- a/artist/templates/multi_plot.tex
+++ b/artist/templates/multi_plot.tex
@@ -51,6 +51,8 @@
                     %
                     xtick=\empty, ytick=\empty,
                     scaled ticks=false,
+                    point meta min={ {{ limits.mmin }} },
+                    point meta max={ {{ limits.mmax }} },
                     {%- if colormap %}
                         colormap/{{ colormap }},
                     {%- else %}
@@ -140,6 +142,12 @@
                         {%- endif %}
                         {%- if subplot.limits.ymax is not none %}
                             ymax={ {{ subplot.limits.ymax }} },
+                        {%- endif %}
+                        {%- if subplot.limits.mmin is not none %}
+                            point meta min={ {{ subplot.limits.mmin }} },
+                        {%- endif %}
+                        {%- if subplot.limits.mmax is not none %}
+                            point meta max={ {{ subplot.limits.mmax }} },
                         {%- endif %}
                     {%- endif %}
                     ]

--- a/artist/templates/multi_plot.tex
+++ b/artist/templates/multi_plot.tex
@@ -71,6 +71,19 @@
                 {% for subplot in subplots %}
                     {% set plot = subplot %}
                     \nextgroupplot[
+                        {%- if loop.last and colorbar %}
+                            colorbar {% if colorbar.horizontal %}horizontal{% endif %},
+                            colorbar style={
+                                tick align=outside,
+                                xtick pos=left,
+                                ytick pos=right,
+                                {%- if colorbar.horizontal %}
+                                    xlabel={{ colorbar.label }},
+                                {%- else %}
+                                    ylabel={{ colorbar.label }},
+                                {%- endif %}
+                                },
+                        {%- endif %}
                     {%- if subplot.empty %}
                         group/empty plot
                     {%- else %}

--- a/artist/templates/multi_plot.tex
+++ b/artist/templates/multi_plot.tex
@@ -74,6 +74,19 @@
                         {%- if loop.last and colorbar %}
                             colorbar {% if colorbar.horizontal %}horizontal{% endif %},
                             colorbar style={
+                                {%- if colorbar.horizontal %}
+                                    width={{ columns }} * \pgfkeysvalueof{/pgfplots/parent axis width} +
+                                          ({{ columns }} - 1) * \pgfkeysvalueof{/pgfplots/group/horizontal sep},
+                                    xshift=-({{ columns }} - 1) *
+                                           (\pgfkeysvalueof{/pgfplots/parent axis width} +
+                                            \pgfkeysvalueof{/pgfplots/group/horizontal sep}),
+                                {%- else %}
+                                    height={{ rows }} * \pgfkeysvalueof{/pgfplots/parent axis height} +
+                                           ({{ rows }} - 1) * \pgfkeysvalueof{/pgfplots/group/vertical sep},
+                                    yshift=({{ rows }} - 1) *
+                                           (\pgfkeysvalueof{/pgfplots/parent axis height} +
+                                            \pgfkeysvalueof{/pgfplots/group/vertical sep}),
+                                {%- endif %}
                                 tick align=outside,
                                 xtick pos=left,
                                 ytick pos=right,

--- a/artist/templates/plot.tex
+++ b/artist/templates/plot.tex
@@ -12,9 +12,9 @@
     {\def\defaultwidth{ {{ width }} }}
 %
 {%- if height %}
-\pgfkeysifdefined{/artist/height}
-    {\pgfkeysgetvalue{/artist/height}{\defaultheight}}
-    {\def\defaultheight{ {{ height }} }}
+    \pgfkeysifdefined{/artist/height}
+        {\pgfkeysgetvalue{/artist/height}{\defaultheight}}
+        {\def\defaultheight{ {{ height }} }}
 {%- endif %}
 %
 \begin{sansmath}
@@ -48,16 +48,16 @@
             xtick={ {{ ticks.x | join(', ') }} },
             ytick={ {{ ticks.y | join(', ') }} },
             {%- if ticks.xlabels %}
-            xticklabels={ {{ ticks.xlabels | join(', ') }} },
+                xticklabels={ {{ ticks.xlabels | join(', ') }} },
             {%- endif %}
             {%- if ticks.ylabels %}
-            yticklabels={ {{ ticks.ylabels | join(', ') }} },
+                yticklabels={ {{ ticks.ylabels | join(', ') }} },
             {%- endif %}
             {%- if ticks.xsuffix %}
-            xticklabel=$\pgfmathprintnumber{\tick}{{ ticks.xsuffix }}$,
+                xticklabel=$\pgfmathprintnumber{\tick}{{ ticks.xsuffix }}$,
             {%- endif %}
             {%- if ticks.ysuffix %}
-            yticklabel=$\pgfmathprintnumber{\tick}{{ ticks.ysuffix }}$,
+                yticklabel=$\pgfmathprintnumber{\tick}{{ ticks.ysuffix }}$,
             {%- endif %}
             %
             tick align=outside,

--- a/artist/templates/plot.tex
+++ b/artist/templates/plot.tex
@@ -65,11 +65,17 @@
             every tick/.style={},
             axis on top,
             {%- if colorbar %}
-                colorbar,
+                colorbar {% if colorbar.horizontal %}horizontal{% endif %},
                 colorbar style={
                     tick align=outside,
+                    xtick pos=left,
                     ytick pos=right,
-                    ylabel={{ colorbar.label }}},
+                    {%- if colorbar.horizontal %}
+                        xlabel={{ colorbar.label }},
+                    {%- else %}
+                        ylabel={{ colorbar.label }},
+                    {%- endif %}
+                    },
             {%- endif %}
             point meta min={ {{ limits.mmin }} },
             point meta max={ {{ limits.mmax }} },

--- a/artist/templates/plot.tex
+++ b/artist/templates/plot.tex
@@ -31,7 +31,7 @@
             ymode={{ ymode }},
             width=\defaultwidth,
             {%- if height %}
-            height=\defaultheight,
+                height=\defaultheight,
             {%- endif %}
             axis equal={{ axis_equal | lower }},
             %
@@ -64,6 +64,24 @@
             max space between ticks=40,
             every tick/.style={},
             axis on top,
+            {%- if colorbar %}
+                colorbar,
+                colorbar style={ylabel={{ colorbar.label }}},
+            {%- endif %}
+            {%- if colormap %}
+                colormap/{{ colormap }},
+            {%- else %}
+                colormap={coolwarm}{
+                    rgb255(0cm)=( 59, 76,192);
+                    rgb255(1cm)=( 98,130,234);
+                    rgb255(2cm)=(141,176,254);
+                    rgb255(3cm)=(184,208,249);
+                    rgb255(4cm)=(221,221,221);
+                    rgb255(5cm)=(245,196,173);
+                    rgb255(6cm)=(244,154,123);
+                    rgb255(7cm)=(222, 96, 77);
+                    rgb255(8cm)=(180,  4, 38)},
+            {%- endif %}
         ]
 
         {% include 'subplot.tex' %}

--- a/artist/templates/plot.tex
+++ b/artist/templates/plot.tex
@@ -66,7 +66,10 @@
             axis on top,
             {%- if colorbar %}
                 colorbar,
-                colorbar style={ylabel={{ colorbar.label }}},
+                colorbar style={
+                    tick align=outside,
+                    ytick pos=right,
+                    ylabel={{ colorbar.label }}},
             {%- endif %}
             {%- if colormap %}
                 colormap/{{ colormap }},

--- a/artist/templates/plot.tex
+++ b/artist/templates/plot.tex
@@ -71,6 +71,8 @@
                     ytick pos=right,
                     ylabel={{ colorbar.label }}},
             {%- endif %}
+            point meta min={ {{ limits.mmin }} },
+            point meta max={ {{ limits.mmax }} },
             {%- if colormap %}
                 colormap/{{ colormap }},
             {%- else %}

--- a/artist/templates/polar_plot.tex
+++ b/artist/templates/polar_plot.tex
@@ -13,11 +13,11 @@
     {\def\defaultwidth{ {{ width }} }}
 \pgfkeysifdefined{/artist/height}
     {\pgfkeysgetvalue{/artist/height}{\defaultheight}}
-{%- if height %}
-    {\def\defaultheight{ {{ height }} }}
-{%- else %}
-    {\def\defaultheight{ {{ width }} }}
-{%- endif %}
+    {%- if height %}
+        {\def\defaultheight{ {{ height }} }}
+    {%- else %}
+        {\def\defaultheight{ {{ width }} }}
+    {%- endif %}
 
 \let\ytickshift\relax
 \newlength{\ytickshift}
@@ -38,7 +38,7 @@
             ymode={{ ymode }},
             width=\defaultwidth,
             {%- if height %}
-            height=\defaultheight,
+                height=\defaultheight,
             {%- endif %}
             axis equal={{ axis_equal | lower }},
             y axis line style={yshift=-.5*\defaultheight},
@@ -61,16 +61,16 @@
             xtick={ {{ ticks.x | join(', ') }} },
             ytick={ {{ ticks.y | join(', ') }} },
             {%- if ticks.xlabels %}
-            xticklabels={ {{ ticks.xlabels | join(', ') }} },
+                xticklabels={ {{ ticks.xlabels | join(', ') }} },
             {%- endif %}
             {%- if ticks.ylabels %}
-            yticklabels={ {{ ticks.ylabels | join(', ') }} },
+                yticklabels={ {{ ticks.ylabels | join(', ') }} },
             {%- endif %}
             {%- if ticks.xsuffix %}
-            xticklabel=$\pgfmathprintnumber{\tick}{{ ticks.xsuffix }}$,
+                xticklabel=$\pgfmathprintnumber{\tick}{{ ticks.xsuffix }}$,
             {%- endif %}
             {%- if ticks.ysuffix %}
-            yticklabel=$\pgfmathprintnumber{\tick}{{ ticks.ysuffix }}$,
+                yticklabel=$\pgfmathprintnumber{\tick}{{ ticks.ysuffix }}$,
             {%- endif %}
             yticklabel shift={\ytickshift},
             xticklabel shift={0.075cm},

--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -85,6 +85,20 @@
     };
 {% endfor %}
 
+{% for table in plot.plot_table_list %}
+    % Draw table plot
+    \addplot[scatter, scatter src=\thisrow{c},
+             visualization depends on={\thisrow{s} \as \s},
+             scatter/@pre marker code/.append style={/tikz/mark size=\s},
+             {{ table.options }}] 
+        table {
+            x y c s
+        {%- for x, y, c, s in table.data %}
+            {{ x }} {{ y }} {{ c }} {{ s }}
+        {%- endfor %}
+        };
+{% endfor %}
+
 {% for line in plot.horizontal_lines %}
     \draw[{{ line.options }}]
         ({rel axis cs:0, 0} |- {axis cs:0, {{ line.value }} }) --

--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -54,15 +54,15 @@
                      { {{ bitmap.name }}};
 {% endfor %}
 
-{% for region in plot.shaded_regions_list %}
+{%- for region in plot.shaded_regions_list %}
     \addplot[draw=none, fill={{ region.color }}] coordinates {
         {%- for x, y in region.data %}
             ({{ x }}, {{ y }})
         {%- endfor %}
             } -- cycle;
-{% endfor %}
+{% endfor -%}
 
-{% for series in plot.plot_series_list %}
+{%- for series in plot.plot_series_list %}
     {% if series.show_xerr %}
         % Draw x-error bars
         {%- for x, y, xerr, yerr in series.data %}
@@ -83,9 +83,9 @@
             ({{ x }}, {{ y }})
         {%- endfor %}
     };
-{% endfor %}
+{% endfor -%}
 
-{% for table in plot.plot_table_list %}
+{%- for table in plot.plot_table_list %}
     {%- if limits.smin is not none and limits.smax is not none %}
         {%- set scale = (limits.smax - limits.smin) / (table.smax - table.smin) %}
     {%- else %}
@@ -107,21 +107,21 @@
             {%- endif %}
         {%- endfor %}
         };
-{% endfor %}
+{% endfor -%}
 
-{% for line in plot.horizontal_lines %}
+{%- for line in plot.horizontal_lines %}
     \draw[{{ line.options }}]
         ({rel axis cs:0, 0} |- {axis cs:0, {{ line.value }} }) --
         ({rel axis cs:1, 1} |- {axis cs:0, {{ line.value }} });
-{% endfor %}
+{% endfor -%}
 
-{% for line in plot.vertical_lines %}
+{%- for line in plot.vertical_lines %}
     \draw[{{ line.options }}]
         ({rel axis cs:0, 0} -| {axis cs:{{ line.value }}, 0 }) --
         ({rel axis cs:1, 1} -| {axis cs:{{ line.value }}, 0 });
-{% endfor %}
+{% endfor -%}
 
-{% for pin in plot.pin_list %}
+{%- for pin in plot.pin_list %}
     {%- if pin.use_arrow %}
         {%- set pin_option = 'pin' %}
     {%- else %}
@@ -130,18 +130,17 @@
     \node[coordinate,{{ pin.options }},
           {{ pin_option }}={ {{ pin.location }}:{ {{ pin.text }} }}]
         at (axis cs:{{ pin.x }}, {{ pin.y }}) {};
-{% endfor %}
+{% endfor -%}
 
-{% if plot.label %}
+{%- if plot.label %}
     \node[{{ plot.label.style }},
     {%- if plot.label.node_location != 'center' %}
           {{ plot.label.node_location }}=2pt
     {%- endif %}
         ]
-        at (rel axis cs:{{ plot.label.x }},
-            {{ plot.label.y }})
+        at (rel axis cs:{{ plot.label.x }},{{ plot.label.y }})
         { {{ plot.label.text }} };
-{% endif %}
+{%- endif %}
 
 {%- if plot.scalebar %}
     {%- set table = plot.plot_table_list[0] %}

--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -142,3 +142,31 @@
             {{ plot.label.y }})
         { {{ plot.label.text }} };
 {% endif %}
+
+{%- if plot.scalebar %}
+    {%- set table = plot.plot_table_list[0] %}
+    {%- set min_size_value = (table.smin * table.smin)|round|int %}
+    {%- set max_size_value = (table.smax * table.smax)|round|int %}
+    {%- if limits.smin is not none and limits.smax is not none %}
+        {%- set scale = (limits.smax - limits.smin) / (table.smax - table.smin) %}
+        {%- set smin = ((min_size_value ** 0.5 - table.smin) * scale) + limits.smin %}
+        {%- set smax = ((max_size_value ** 0.5 - table.smin) * scale) + limits.smin %}
+    {%- else %}
+        {%- set smin = min_size_value %}
+        {%- set smax = max_size_value %}
+    {%- endif %}
+
+    \node[
+        {%- if plot.scalebar.node_location != 'center' %}
+            {{ plot.scalebar.node_location }}=0pt
+        {%- endif %}
+        ]
+        at (rel axis cs:{{ plot.scalebar.x }}, {{ plot.scalebar.y }}) {
+            \begin{tikzpicture}[gray]
+                {%- if smin != 0 %}
+                    \draw[xshift=-{{ 1.5 * smin }}pt] (0,0) circle ({{ smin }}pt) node[yshift=-{{ smin }}pt,anchor=north] { \small{ {{ min_size_value }} } }; \\
+                {%- endif %}
+                \draw[xshift={{ 1.5 * smax }}pt] (0,0) circle ({{ smax }}pt) node[anchor=north,yshift=-{{ smax }}pt] { \small{ {{ max_size_value }} } };
+            \end{tikzpicture}
+        };
+{%- endif %}

--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -91,9 +91,6 @@
     {%- else %}
         {%- set scale = 1 %}
     {%- endif %}
-    % {{ scale }}
-    % {{ limits }}
-    % {{ table }}
     % Draw table plot
     \addplot[scatter, scatter src=\thisrow{c},
              visualization depends on={\thisrow{s} \as \s},

--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -163,9 +163,11 @@
         at (rel axis cs:{{ plot.scalebar.x }}, {{ plot.scalebar.y }}) {
             \begin{tikzpicture}[gray]
                 {%- if smin != 0 %}
-                    \draw[xshift=-{{ 1.5 * smin }}pt] (0,0) circle ({{ smin }}pt) node[yshift=-{{ smin }}pt,anchor=north] { \small{ {{ min_size_value }} } }; \\
+                    \draw[xshift=-{{ 1.5 * smin }}pt] (0,0) circle ({{ smin }}pt)
+                        node[yshift=-{{ smin }}pt,anchor=north] { \small{ {{ min_size_value }} } };
                 {%- endif %}
-                \draw[xshift={{ 1.5 * smax }}pt] (0,0) circle ({{ smax }}pt) node[anchor=north,yshift=-{{ smax }}pt] { \small{ {{ max_size_value }} } };
+                \draw[xshift={{ 1.5 * smax }}pt] (0,0) circle ({{ smax }}pt)
+                    node[anchor=north,yshift=-{{ smax }}pt] { \small{ {{ max_size_value }} } };
             \end{tikzpicture}
         };
 {%- endif %}

--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -151,8 +151,8 @@
         {%- set smin = ((min_size_value ** 0.5 - table.smin) * scale) + limits.smin %}
         {%- set smax = ((max_size_value ** 0.5 - table.smin) * scale) + limits.smin %}
     {%- else %}
-        {%- set smin = min_size_value %}
-        {%- set smax = max_size_value %}
+        {%- set smin = min_size_value ** 0.5 %}
+        {%- set smax = max_size_value ** 0.5 %}
     {%- endif %}
 
     \node[

--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -86,15 +86,28 @@
 {% endfor %}
 
 {% for table in plot.plot_table_list %}
+    {%- if limits.smin is not none and limits.smax is not none %}
+        {%- set scale = (limits.smax - limits.smin) / (table.smax - table.smin) %}
+    {%- else %}
+        {%- set scale = 1 %}
+    {%- endif %}
+    % {{ scale }}
+    % {{ limits }}
+    % {{ table }}
     % Draw table plot
     \addplot[scatter, scatter src=\thisrow{c},
              visualization depends on={\thisrow{s} \as \s},
              scatter/@pre marker code/.append style={/tikz/mark size=\s},
-             {{ table.options }}] 
+             {{ table.options }}]
         table {
             x y c s
         {%- for x, y, c, s in table.data %}
-            {{ x }} {{ y }} {{ c }} {{ s }}
+            {%- if limits.smin is not none and limits.smax is not none %}
+                {%- set s_scaled = ((s - table.smin) * scale) + limits.smin %}
+                {{ x }} {{ y }} {{ c }} {{ s_scaled }}
+            {%- else %}
+                {{ x }} {{ y }} {{ c }} {{ s }}
+            {%- endif %}
         {%- endfor %}
         };
 {% endfor %}

--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -29,19 +29,19 @@
 
             {%- if weight > 0 %}
                 {%- if histogram.type == 'area' %}
-                \draw[{{ histogram.style }},
-                      scale around={ {{ count / histogram.max }}:
-                                    (axis cs: {{ x }}, {{ y }})}]
-                    (axis cs:{{ x0 }}, {{ y0 }})
-                    rectangle (axis cs:{{ x1 }}, {{ y1 }});
+                    \draw[{{ histogram.style }},
+                          scale around={ {{ count / histogram.max }}:
+                                        (axis cs: {{ x }}, {{ y }})}]
+                        (axis cs:{{ x0 }}, {{ y0 }})
+                        rectangle (axis cs:{{ x1 }}, {{ y1 }});
                 {%- elif histogram.type in ['bw', 'reverse_bw'] %}
-                \path[{{ histogram.style }},fill,
-                    {%- if 'reverse' in histogram.type %}
-                        {%- set weight = 100 - weight %}
-                    {%- endif %}
-                      black!{{ 100 - weight }}]
-                    (axis cs:{{ x0 }}, {{ y0 }})
-                    rectangle (axis cs:{{ x1 }}, {{ y1 }});
+                    \path[{{ histogram.style }},fill,
+                        {%- if 'reverse' in histogram.type %}
+                            {%- set weight = 100 - weight %}
+                        {%- endif %}
+                          black!{{ 100 - weight }}]
+                        (axis cs:{{ x0 }}, {{ y0 }})
+                        rectangle (axis cs:{{ x1 }}, {{ y1 }});
                 {%- endif %}
             {%- endif %}
         {%- endfor %}
@@ -56,32 +56,32 @@
 
 {% for region in plot.shaded_regions_list %}
     \addplot[draw=none, fill={{ region.color }}] coordinates {
-    {%- for x, y in region.data %}
-        ({{ x }}, {{ y }})
-    {%- endfor %}
-        } -- cycle;
+        {%- for x, y in region.data %}
+            ({{ x }}, {{ y }})
+        {%- endfor %}
+            } -- cycle;
 {% endfor %}
 
 {% for series in plot.plot_series_list %}
     {% if series.show_xerr %}
-    % Draw x-error bars
-    {%- for x, y, xerr, yerr in series.data %}
-    \draw (axis cs:{{ x - xerr }}, {{ y }}) --
-          (axis cs:{{ x + xerr }}, {{ y }});
-    {%- endfor %}
+        % Draw x-error bars
+        {%- for x, y, xerr, yerr in series.data %}
+            \draw (axis cs:{{ x - xerr }}, {{ y }}) --
+                  (axis cs:{{ x + xerr }}, {{ y }});
+        {%- endfor %}
     {%- endif %}
     {%- if series.show_yerr %}
-    % Draw y-error bars
-    {%- for x, y, xerr, yerr in series.data %}
-    \draw (axis cs:{{ x }}, {{ y - yerr }}) --
-          (axis cs:{{ x }}, {{ y + yerr }});
-    {%- endfor %}
+        % Draw y-error bars
+        {%- for x, y, xerr, yerr in series.data %}
+            \draw (axis cs:{{ x }}, {{ y - yerr }}) --
+                  (axis cs:{{ x }}, {{ y + yerr }});
+        {%- endfor %}
     {% endif %}
     % Draw series plot
     \addplot[{{ series.options }}] coordinates {
-    {%- for x, y, xerr, yerr in series.data %}
-        ({{ x }}, {{ y }})
-    {%- endfor %}
+        {%- for x, y, xerr, yerr in series.data %}
+            ({{ x }}, {{ y }})
+        {%- endfor %}
     };
 {% endfor %}
 

--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -101,9 +101,9 @@
         {%- for x, y, c, s in table.data %}
             {%- if limits.smin is not none and limits.smax is not none %}
                 {%- set s_scaled = ((s - table.smin) * scale) + limits.smin %}
-                {{ x }} {{ y }} {{ c }} {{ s_scaled }}
+                {{ x }} {{ y }} {{ c }} {{ s_scaled }}pt
             {%- else %}
-                {{ x }} {{ y }} {{ c }} {{ s }}
+                {{ x }} {{ y }} {{ c }} {{ s }}pt
             {%- endif %}
         {%- endfor %}
         };

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -17,14 +17,16 @@ distclean: clean
 	rm -f polar_histogram.tex
 	rm -f discrete_directions.tex
 	rm -f histogram2d.tex
+	rm -f multi_histogram2d.tex
 	rm -f event_display.tex
+	rm -f multi_event_display.tex
 
 demo_plots.pdf: demo_plots.tex \
 		stopping-power-mpl.pdf stopping-power.tex \
 		shower-front.tex eas-lateral.tex histogram-fit.tex \
 		spectrum.tex sciencepark.tex multiplot.tex polar_histogram.tex \
 		discrete_directions.tex histogram2d.tex multi_histogram2d.tex \
-		event_display.tex
+		event_display.tex multi_event_display.tex
 	latexmk -pdf demo_plots.tex
 
 stopping-power-mpl.pdf stopping-power.tex: demo_stopping_power.py
@@ -57,5 +59,5 @@ discrete_directions.tex: demo_discrete_directions.py
 histogram2d.tex multi_histogram2d.tex: demo_histogram2d.py
 	python $?
 
-event_display.tex: demo_event_display.py
+event_display.tex multi_event_display.tex: demo_event_display.py
 	python $?

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -17,12 +17,14 @@ distclean: clean
 	rm -f polar_histogram.tex
 	rm -f discrete_directions.tex
 	rm -f histogram2d.tex
+	rm -f event_display.tex
 
 demo_plots.pdf: demo_plots.tex \
 		stopping-power-mpl.pdf stopping-power.tex \
 		shower-front.tex eas-lateral.tex histogram-fit.tex \
 		spectrum.tex sciencepark.tex multiplot.tex polar_histogram.tex \
-		discrete_directions.tex histogram2d.tex multi_histogram2d.tex
+		discrete_directions.tex histogram2d.tex multi_histogram2d.tex \
+		event_display.tex
 	latexmk -pdf demo_plots.tex
 
 stopping-power-mpl.pdf stopping-power.tex: demo_stopping_power.py
@@ -53,4 +55,7 @@ discrete_directions.tex: demo_discrete_directions.py
 	python $?
 
 histogram2d.tex multi_histogram2d.tex: demo_histogram2d.py
+	python $?
+
+event_display.tex: demo_event_display.py
 	python $?

--- a/demo/demo_event_display.py
+++ b/demo/demo_event_display.py
@@ -57,8 +57,10 @@ def main():
     plot = MultiPlot(1, 2, width=r'.5\linewidth')
     plot.set_xlimits_for_all(min=-10, max=15)
     plot.set_ylimits_for_all(min=-15, max=10)
+    plot.set_mlimits_for_all(min=0., max=16.)
+    plot.set_colorbar('$\Delta$t [ns]', False)
     plot.set_colormap('blackwhite')
-    plot.set_mlimits_for_all(max=16.)
+    plot.set_scalebar_for_all(location="upper right")
 
     p = plot.get_subplot_at(0, 0)
     p.scatter([0], [0], mark='triangle')
@@ -74,8 +76,6 @@ def main():
 
     plot.show_yticklabels_for_all([(0, 0)])
     plot.show_xticklabels_for_all([(0, 0), (0, 1)])
-
-    plot.set_scalebar_for_all(location="upper right")
 
     plot.set_xlabel('x [m]')
     plot.set_ylabel('y [m]')

--- a/demo/demo_event_display.py
+++ b/demo/demo_event_display.py
@@ -33,7 +33,7 @@ def main():
     plot.set_colorbar('$\Delta$t [ns]')
     plot.set_axis_equal()
     plot.set_mlimits(max=16.)
-    plot.set_slimits(min=5, max=20)
+    plot.set_slimits(min=10., max=100.)
 
     plot.set_xlabel('x [m]')
     plot.set_ylabel('y [m]')
@@ -58,7 +58,7 @@ def main():
     plot.set_ylimits_for_all(min=-15, max=10)
     plot.set_colormap('blackwhite')
     plot.set_mlimits_for_all(max=16.)
-    plot.set_slimits_for_all(min=5., max=10.)
+    plot.set_slimits_for_all(min=10., max=50.)
 
     p = plot.get_subplot_at(0, 0)
     p.scatter([0], [0], mark='triangle')

--- a/demo/demo_event_display.py
+++ b/demo/demo_event_display.py
@@ -1,0 +1,35 @@
+from artist import Plot
+
+
+def main():
+    """Event display for an event of station 503
+
+    Date        Time      Timestamp   Nanoseconds
+    2012-03-29  10:51:36  1333018296  870008589
+
+    Number of MIPs
+    35.046  51.932  35.780  78.873
+
+    Arrival time
+    15      17.5    20      27.5
+
+    """
+    scale = 5.
+    plot = Plot()
+    plot.scatter([0], [0])
+    plot.add_pin_at_xy(0, 0, 'Station 503', use_arrow=False, location='below')
+    plot.scatter_table([-6.34, -2.23, -3.6, 3.46],
+                       [6.34, 2.23, -3.6, 3.46],
+                       [15, 17.5, 20, 27.5],
+                       [35 / scale, 52 / scale, 36 / scale, 79 / scale])
+
+    plot.set_colorbar('$\Delta$t [ns]')
+    plot.set_axis_equal()
+    plot.set_xlabel('x [m]')
+    plot.set_ylabel('y [m]')
+
+    plot.save('event_display')
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/demo_event_display.py
+++ b/demo/demo_event_display.py
@@ -34,6 +34,7 @@ def main():
 
     plot.set_colorbar('$\Delta$t [ns]')
     plot.set_axis_equal()
+    plot.set_mlimits(max=16.)
     plot.set_xlabel('x [m]')
     plot.set_ylabel('y [m]')
 
@@ -58,6 +59,7 @@ def main():
     plot.set_xlimits_for_all(min=-10, max=15)
     plot.set_ylimits_for_all(min=-15, max=10)
     plot.set_colormap('blackwhite')
+    plot.set_mlimits_for_all(max=16.)
 
     p = plot.get_subplot_at(0, 0)
     p.scatter([0], [0], mark='triangle')

--- a/demo/demo_event_display.py
+++ b/demo/demo_event_display.py
@@ -59,7 +59,6 @@ def main():
     plot.set_ylimits_for_all(min=-15, max=10)
     plot.set_colormap('blackwhite')
     plot.set_mlimits_for_all(max=16.)
-    plot.set_slimits_for_all(min=10., max=50.)
 
     p = plot.get_subplot_at(0, 0)
     p.scatter([0], [0], mark='triangle')
@@ -75,6 +74,8 @@ def main():
 
     plot.show_yticklabels_for_all([(0, 0)])
     plot.show_xticklabels_for_all([(0, 0), (0, 1)])
+
+    plot.set_scalebar_for_all(location="upper right")
 
     plot.set_xlabel('x [m]')
     plot.set_ylabel('y [m]')

--- a/demo/demo_event_display.py
+++ b/demo/demo_event_display.py
@@ -1,4 +1,4 @@
-from artist import Plot
+from artist import Plot, MultiPlot
 
 
 def main():
@@ -8,20 +8,29 @@ def main():
     2012-03-29  10:51:36  1333018296  870008589
 
     Number of MIPs
-    35.046  51.932  35.780  78.873
+    35.0  51.9  35.8  78.9
 
     Arrival time
-    15      17.5    20      27.5
+    15.0  17.5  20.0  27.5
 
     """
-    scale = 5.
+    # Detector positions in ENU relative to the station GPS
+    x = [-6.34, -2.23, -3.6, 3.46]
+    y = [6.34, 2.23, -3.6, 3.46]
+
+    # Scale mips to fit the graph
+    n = [35.0, 51.9, 35.8, 78.9]
+    scale = 5.0
+    n_scaled = [ni / scale for ni in n]
+
+    # Make times relative to first detection
+    t = [15., 17.5, 20., 27.5]
+    dt = [ti - min(t) for ti in t]
+
     plot = Plot()
-    plot.scatter([0], [0])
+    plot.scatter([0], [0], mark='triangle')
     plot.add_pin_at_xy(0, 0, 'Station 503', use_arrow=False, location='below')
-    plot.scatter_table([-6.34, -2.23, -3.6, 3.46],
-                       [6.34, 2.23, -3.6, 3.46],
-                       [15, 17.5, 20, 27.5],
-                       [35 / scale, 52 / scale, 36 / scale, 79 / scale])
+    plot.scatter_table(x, y, dt, n_scaled)
 
     plot.set_colorbar('$\Delta$t [ns]')
     plot.set_axis_equal()
@@ -29,6 +38,46 @@ def main():
     plot.set_ylabel('y [m]')
 
     plot.save('event_display')
+
+
+    # Add event by Station 508
+    # Detector positions in ENU relative to the station GPS
+    x508 = [6.12, 0.00, -3.54, 3.54]
+    y508 = [-6.12, -13.23, -3.54, 3.54]
+
+    # Event GPS timestamp: 1371498167.016412100
+    # MIPS
+    n508 = [5.6, 16.7, 36.6, 9.0]
+    scale = 5.0
+    n508_scaled = [ni / scale for ni in n508]
+    # Arrival Times
+    t508 = [15., 22.5, 22.5, 30.]
+    dt508 = [ti - min(t508) for ti in t508]
+
+    plot = MultiPlot(1, 2, width=r'.5\linewidth')
+    plot.set_xlimits_for_all(min=-10, max=15)
+    plot.set_ylimits_for_all(min=-15, max=10)
+    plot.set_colormap('blackwhite')
+
+    p = plot.get_subplot_at(0, 0)
+    p.scatter([0], [0], mark='triangle')
+    p.add_pin_at_xy(0, 0, 'Station 503', use_arrow=False, location='below')
+    p.scatter_table(x, y, dt, n_scaled)
+    p.set_axis_equal()
+
+    p = plot.get_subplot_at(0, 1)
+    p.scatter([0], [0], mark='triangle')
+    p.add_pin_at_xy(0, 0, 'Station 508', use_arrow=False, location='below')
+    p.scatter_table(x508, y508, dt508, n508_scaled)
+    p.set_axis_equal()
+
+    plot.show_yticklabels_for_all([(0, 0)])
+    plot.show_xticklabels_for_all([(0, 0), (0, 1)])
+
+    plot.set_xlabel('x [m]')
+    plot.set_ylabel('y [m]')
+
+    plot.save('multi_event_display')
 
 
 if __name__ == '__main__':

--- a/demo/demo_event_display.py
+++ b/demo/demo_event_display.py
@@ -20,8 +20,6 @@ def main():
 
     # Scale mips to fit the graph
     n = [35.0, 51.9, 35.8, 78.9]
-    scale = 5.0
-    n_scaled = [ni / scale for ni in n]
 
     # Make times relative to first detection
     t = [15., 17.5, 20., 27.5]
@@ -30,11 +28,13 @@ def main():
     plot = Plot()
     plot.scatter([0], [0], mark='triangle')
     plot.add_pin_at_xy(0, 0, 'Station 503', use_arrow=False, location='below')
-    plot.scatter_table(x, y, dt, n_scaled)
+    plot.scatter_table(x, y, dt, n)
 
     plot.set_colorbar('$\Delta$t [ns]')
     plot.set_axis_equal()
     plot.set_mlimits(max=16.)
+    plot.set_slimits(min=5, max=20)
+
     plot.set_xlabel('x [m]')
     plot.set_ylabel('y [m]')
 
@@ -49,8 +49,6 @@ def main():
     # Event GPS timestamp: 1371498167.016412100
     # MIPS
     n508 = [5.6, 16.7, 36.6, 9.0]
-    scale = 5.0
-    n508_scaled = [ni / scale for ni in n508]
     # Arrival Times
     t508 = [15., 22.5, 22.5, 30.]
     dt508 = [ti - min(t508) for ti in t508]
@@ -60,17 +58,18 @@ def main():
     plot.set_ylimits_for_all(min=-15, max=10)
     plot.set_colormap('blackwhite')
     plot.set_mlimits_for_all(max=16.)
+    plot.set_slimits_for_all(min=5., max=10.)
 
     p = plot.get_subplot_at(0, 0)
     p.scatter([0], [0], mark='triangle')
     p.add_pin_at_xy(0, 0, 'Station 503', use_arrow=False, location='below')
-    p.scatter_table(x, y, dt, n_scaled)
+    p.scatter_table(x, y, dt, n)
     p.set_axis_equal()
 
     p = plot.get_subplot_at(0, 1)
     p.scatter([0], [0], mark='triangle')
     p.add_pin_at_xy(0, 0, 'Station 508', use_arrow=False, location='below')
-    p.scatter_table(x508, y508, dt508, n508_scaled)
+    p.scatter_table(x508, y508, dt508, n508)
     p.set_axis_equal()
 
     plot.show_yticklabels_for_all([(0, 0)])

--- a/demo/demo_event_display.py
+++ b/demo/demo_event_display.py
@@ -30,6 +30,7 @@ def main():
     plot.add_pin_at_xy(0, 0, 'Station 503', use_arrow=False, location='below')
     plot.scatter_table(x, y, dt, n)
 
+    plot.set_scalebar(location="lower right")
     plot.set_colorbar('$\Delta$t [ns]')
     plot.set_axis_equal()
     plot.set_mlimits(max=16.)

--- a/demo/demo_plots.tex
+++ b/demo/demo_plots.tex
@@ -114,4 +114,12 @@ indicates the number of particles in each detector. The color is based
 on the arrival time of the particles.}
 \end{figure}
 
+\begin{figure}
+\centering
+\input{multi_event_display}
+\caption{Two detected air showers, one by station 503 and one by station
+508. The size of the points indicates the number of particles in each
+detector. The color is based on the arrival time of the particles.}
+\end{figure}
+
 \end{document}

--- a/demo/demo_plots.tex
+++ b/demo/demo_plots.tex
@@ -106,4 +106,12 @@ reverse\_bw, and right: bw.}
 bitmap, left: reverse\_bw, and right: bw.}
 \end{figure}
 
+\begin{figure}
+\centering
+\input{event_display}
+\caption{A detected air shower by station 503. The size of the points
+indicates the number of particles in each detector. The color is based
+on the arrival time of the particles.}
+\end{figure}
+
 \end{document}


### PR DESCRIPTION
Add new function that can be used to 'easily' control size and color of each point.
4 equal length arrays define the position, color and size of each point. The colors are mapped to the active colormap.

Todo:
- [x] Point sizes
    - [x] Point size value should define the area of the point, not its radius.
    - [x] Scale point sizes to reasonable values (perhaps add option for min/max size and scale linearly between them), because axis bounds ignore (large) point sizes
    - [x] Scale bar for the size of the points (show what value corresponds to what size)
- [x] Allow setting of the min and max value for the colormap mapping (`point meta min/max`)
- [x] Allow more options for colorbar (e.g. horizontal)
- [x] MultiPlot
    - [x] Plotting
    - [x] Colorbar in MultiPlot
    - [x] Scale bar for MultiPlot

Comments are welcome.