### PR TITLE
Add name for externalised files

### DIFF
--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -461,7 +461,7 @@ class MultiPlot(BasePlotContainer):
                                    limits=self.limits, ticks=self.ticks,
                                    colorbar=self.colorbar,
                                    colormap=self.colormap,
-                                   filename=self.filename,
+                                   external_filename=self.external_filename,
                                    subplots=self.subplots,
                                    plot_template=self.template)
         return response

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -461,6 +461,7 @@ class MultiPlot(BasePlotContainer):
                                    limits=self.limits, ticks=self.ticks,
                                    colorbar=self.colorbar,
                                    colormap=self.colormap,
+                                   filename=self.filename,
                                    subplots=self.subplots,
                                    plot_template=self.template)
         return response

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -104,7 +104,7 @@ class BasePlotContainer(object):
 
         """
         self.save_assets(dest_path)
-        self.filename = 'externalized-' + os.path.basename(dest_path)
+        self.external_filename = 'externalized-' + os.path.basename(dest_path)
         dest_path = self._add_extension('tex', dest_path)
         with open(dest_path, 'w') as f:
             f.write(self.render())
@@ -116,7 +116,7 @@ class BasePlotContainer(object):
 
         """
         self.save_assets(dest_path)
-        self.filename = 'externalized-' + os.path.basename(dest_path)
+        self.external_filename = 'externalized-' + os.path.basename(dest_path)
         dest_path = self._add_extension('tex', dest_path)
         with open(dest_path, 'w') as f:
             f.write(self.render_as_document())
@@ -894,7 +894,7 @@ class Plot(SubPlot, BasePlotContainer):
         self.width = width
         self.height = height
         self.xmode, self.ymode = self._get_axis_modes(axis)
-        self.filename = None
+        self.external_filename = None
 
         super(Plot, self).__init__()
 
@@ -928,7 +928,7 @@ class Plot(SubPlot, BasePlotContainer):
             scalebar=self.scalebar,
             colorbar=self.colorbar,
             colormap=self.colormap,
-            filename=self.filename,
+            external_filename=self.external_filename,
             plot=self,
             plot_template=self.template)
         return response

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -104,6 +104,7 @@ class BasePlotContainer(object):
 
         """
         self.save_assets(dest_path)
+        self.filename = 'externalized-' + os.path.basename(dest_path)
         dest_path = self._add_extension('tex', dest_path)
         with open(dest_path, 'w') as f:
             f.write(self.render())
@@ -115,6 +116,7 @@ class BasePlotContainer(object):
 
         """
         self.save_assets(dest_path)
+        self.filename = 'externalized-' + os.path.basename(dest_path)
         dest_path = self._add_extension('tex', dest_path)
         with open(dest_path, 'w') as f:
             f.write(self.render_as_document())
@@ -892,6 +894,7 @@ class Plot(SubPlot, BasePlotContainer):
         self.width = width
         self.height = height
         self.xmode, self.ymode = self._get_axis_modes(axis)
+        self.filename = None
 
         super(Plot, self).__init__()
 
@@ -925,6 +928,7 @@ class Plot(SubPlot, BasePlotContainer):
             scalebar=self.scalebar,
             colorbar=self.colorbar,
             colormap=self.colormap,
+            filename=self.filename,
             plot=self,
             plot_template=self.template)
         return response

--- a/artist/templates/document.tex
+++ b/artist/templates/document.tex
@@ -2,7 +2,7 @@
 
 \usepackage{a4wide}
 \usepackage{tikz}
-\usetikzlibrary{arrows,pgfplots.groupplots}
+\usetikzlibrary{arrows,pgfplots.groupplots,external}
 \usepackage{pgfplots}
 \pgfplotsset{compat=1.3}
 \usepgfplotslibrary{polar}

--- a/artist/templates/multi_plot.tex
+++ b/artist/templates/multi_plot.tex
@@ -1,5 +1,5 @@
 % \usepackage{tikz}
-% \usetikzlibrary{arrows,pgfplots.groupplots}
+% \usetikzlibrary{arrows,pgfplots.groupplots,external}
 % \usepackage{pgfplots}
 % \pgfplotsset{compat=1.3}
 % \usepackage[detect-family]{siunitx}
@@ -7,6 +7,9 @@
 % \sisetup{text-sf=\sansmath}
 % \usepackage{relsize}
 %
+{%- if filename %}
+    \tikzsetnextfilename{ {{ filename }} }
+{%- endif %}
 \pgfkeysifdefined{/artist/width}
     {\pgfkeysgetvalue{/artist/width}{\defaultwidth}}
     {\def\defaultwidth{ {{ width }} }}

--- a/artist/templates/plot.tex
+++ b/artist/templates/plot.tex
@@ -8,7 +8,7 @@
 % \usepackage{relsize}
 %
 {%- if filename %}
-    \tikzsetnextfilename{ {{ filename }} }
+    \tikzsetnextfilename{ {{ external_filename }} }
 {%- endif %}
 \pgfkeysifdefined{/artist/width}
     {\pgfkeysgetvalue{/artist/width}{\defaultwidth}}

--- a/artist/templates/plot.tex
+++ b/artist/templates/plot.tex
@@ -1,5 +1,5 @@
 % \usepackage{tikz}
-% \usetikzlibrary{arrows}
+% \usetikzlibrary{arrows,external}
 % \usepackage{pgfplots}
 % \pgfplotsset{compat=1.3}
 % \usepackage[detect-family]{siunitx}
@@ -7,6 +7,9 @@
 % \sisetup{text-sf=\sansmath}
 % \usepackage{relsize}
 %
+{%- if filename %}
+    \tikzsetnextfilename{ {{ filename }} }
+{%- endif %}
 \pgfkeysifdefined{/artist/width}
     {\pgfkeysgetvalue{/artist/width}{\defaultwidth}}
     {\def\defaultwidth{ {{ width }} }}

--- a/artist/templates/polar_plot.tex
+++ b/artist/templates/polar_plot.tex
@@ -1,5 +1,5 @@
 % \usepackage{tikz}
-% \usetikzlibrary{arrows}
+% \usetikzlibrary{arrows,external}
 % \usepackage{pgfplots}
 % \pgfplotsset{compat=1.3}
 % \usepgfplotslibrary{polar}
@@ -7,7 +7,10 @@
 % \usepackage[eulergreek]{sansmath}
 % \sisetup{text-sf=\sansmath}
 % \usepackage{relsize}
-
+%
+{%- if filename %}
+    \tikzsetnextfilename{ {{ external_filename }} }
+{%- endif %}
 \pgfkeysifdefined{/artist/width}
     {\pgfkeysgetvalue{/artist/width}{\defaultwidth}}
     {\def\defaultwidth{ {{ width }} }}


### PR DESCRIPTION
See #12

Use the document name for `\tikzsetnextfilename`, prefixed by ‘externalized-‘
Provides recognisable filenames for externalised files.
Requires `\usetikzlibrary{external}`.
Add `\tikzexternalize` to the preamble to externalise the images.

note; Using `\tikzexternalize` also requires `-shell-escape` in the `pdflatex/latexmk` command.

@davidfokkema Like this?