### PR TITLE
Fixing relative imports

### DIFF
--- a/artist/__init__.py
+++ b/artist/__init__.py
@@ -57,9 +57,9 @@ The following modules are included:
     based on the name of the function creating the plot.
 
 """
-from plot import Plot, PolarPlot
-from multi_plot import MultiPlot
-from recursive_smooth import smooth
+from .plot import Plot, PolarPlot
+from .multi_plot import MultiPlot
+from .recursive_smooth import smooth
 
 # Backwards compatibility
-from plot import Plot as GraphArtist
+from .plot import Plot as GraphArtist

--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -20,7 +20,7 @@ import warnings
 
 import jinja2
 
-from plot import BasePlotContainer, SubPlot
+from .plot import BasePlotContainer, SubPlot
 
 
 class MultiPlot(BasePlotContainer):

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -383,8 +383,14 @@ class SubPlot(object):
                    if x is not None)
         ymin = min(y for y in (min(y_edges), self.limits['ymin'])
                    if y is not None)
-        self.set_xlimits(xmin, max(max(x_edges), self.limits['xmax']))
-        self.set_ylimits(ymin, max(max(y_edges), self.limits['ymax']))
+        xmax = max(x_edges)
+        ymax = max(y_edges)
+        if self.limits['xmax'] is not None:
+            xmax = max(xmax, self.limits['xmax'])
+        if self.limits['ymax'] is not None:
+            ymax = max(ymax, self.limits['ymax'])
+        self.set_xlimits(xmin, xmax)
+        self.set_ylimits(ymin, ymax)
 
     def scatter(self, x, y, mark='o', markstyle=None):
         """Plot a series of points.
@@ -577,8 +583,12 @@ class SubPlot(object):
                    if x is not None)
         ymin = min(y for y in (ymin, self.limits['ymin'])
                    if y is not None)
-        self.set_xlimits(xmin, max(xmax, self.limits['xmax']))
-        self.set_ylimits(ymin, max(ymax, self.limits['ymax']))
+        if self.limits['xmax'] is not None:
+            xmax = max(xmax, self.limits['xmax'])
+        if self.limits['ymax'] is not None:
+            ymax = max(ymax, self.limits['ymax'])
+        self.set_xlimits(xmin, xmax)
+        self.set_ylimits(ymin, ymax)
 
     def draw_horizontal_line(self, yvalue, linestyle=None):
         """Draw a horizontal line.

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -489,7 +489,7 @@ class SubPlot(object):
                 "First plot a data series, before using this function")
 
         data = series['data']
-        series_x, series_y = zip(*data)[:2]
+        series_x, series_y = list(zip(*data))[:2]
 
         if x is not None:
             y = np.interp(x, series_x, series_y)

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -21,7 +21,13 @@ import subprocess
 import os
 import tempfile
 import shutil
-from itertools import izip_longest
+try:
+    # Python 2
+    from itertools import izip_longest
+except ImportError:
+    # Python 3
+    from itertools import zip_longest as izip_longest
+
 from math import log10, sqrt
 
 from PIL import Image

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -383,12 +383,10 @@ class SubPlot(object):
                    if x is not None)
         ymin = min(y for y in (min(y_edges), self.limits['ymin'])
                    if y is not None)
-        xmax = max(x_edges)
-        ymax = max(y_edges)
-        if self.limits['xmax'] is not None:
-            xmax = max(xmax, self.limits['xmax'])
-        if self.limits['ymax'] is not None:
-            ymax = max(ymax, self.limits['ymax'])
+        xmax = max(x for x in (max(x_edges), self.limits['xmax'])
+                   if x is not None)
+        ymax = max(y for y in (max(y_edges), self.limits['ymax'])
+                   if y is not None)
         self.set_xlimits(xmin, xmax)
         self.set_ylimits(ymin, ymax)
 
@@ -583,10 +581,10 @@ class SubPlot(object):
                    if x is not None)
         ymin = min(y for y in (ymin, self.limits['ymin'])
                    if y is not None)
-        if self.limits['xmax'] is not None:
-            xmax = max(xmax, self.limits['xmax'])
-        if self.limits['ymax'] is not None:
-            ymax = max(ymax, self.limits['ymax'])
+        xmax = max(x for x in (xmax, self.limits['xmax'])
+                   if x is not None)
+        ymax = max(y for y in (ymax, self.limits['ymax'])
+                   if y is not None)
         self.set_xlimits(xmin, xmax)
         self.set_ylimits(ymin, ymax)
 

--- a/demo/demo_histogram_fit.py
+++ b/demo/demo_histogram_fit.py
@@ -23,7 +23,7 @@ def main():
     # fit normal distribution pdf to data
     f = lambda x, N, mu, sigma: N * scipy.stats.norm.pdf(x, mu, sigma)
     popt, pcov = scipy.optimize.curve_fit(f, x, y)
-    print "Parameters from fit (N, mu, sigma):", popt
+    print("Parameters from fit (N, mu, sigma):", popt)
 
     # make graph
     graph = Plot()

--- a/demo/demo_sciencepark.py
+++ b/demo/demo_sciencepark.py
@@ -21,7 +21,7 @@ def main():
     locations[5] = 'above right'
     locations = iter(locations)
     for num, x, y in stations:
-        graph.add_pin_at_xy(x, y, int(num), location=locations.next(),
+        graph.add_pin_at_xy(x, y, int(num), location=next(locations),
                             use_arrow=False, style='gray,label distance=1ex')
 
     x = [stations['x'][u] for u in [0, 2, 5]]


### PR DESCRIPTION
In the process of making artist python 3 compatible, the only acceptable syntax for relative imports is from .[module] import
name. All import forms not starting with . are interpreted as absolute
imports. (PEP 0328). Of course, this is backward compatible and seems to work with Python 2.7. 