### PR TITLE
Add option to set the style of the xy labels

### DIFF
--- a/artist/plot.py
+++ b/artist/plot.py
@@ -749,7 +749,7 @@ class SubPlot(object):
         """
         self.ticks['y'] = ['1e%d' % u for u in logticks]
 
-    def set_xtick_labels(self, labels):
+    def set_xtick_labels(self, labels, style=None):
         """Set tick labels for the x-axis.
 
         Also set the x-ticks positions to ensure the labels end up on
@@ -759,8 +759,9 @@ class SubPlot(object):
 
         """
         self.ticks['xlabels'] = labels
+        self.ticks['xlabel_style'] = style
 
-    def set_ytick_labels(self, labels):
+    def set_ytick_labels(self, labels, style=None):
         """Set tick labels for the y-axis.
 
         Also set the y-ticks positions to ensure the labels end up on
@@ -770,6 +771,7 @@ class SubPlot(object):
 
         """
         self.ticks['ylabels'] = labels
+        self.ticks['ylabel_style'] = style
 
     def set_xtick_suffix(self, suffix):
         """Set the suffix for the ticks of the x-axis.

--- a/artist/templates/plot.tex
+++ b/artist/templates/plot.tex
@@ -63,6 +63,8 @@
             {%- if ticks.ysuffix %}
                 yticklabel=$\pgfmathprintnumber{\tick}{{ ticks.ysuffix }}$,
             {%- endif %}
+            xticklabel style={ {{ ticks.xlabel_style }} },
+            yticklabel style={ {{ ticks.ylabel_style }} },
             %
             tick align=outside,
             max space between ticks=40,


### PR DESCRIPTION
For example `style=r'font=\sffamily\tiny'`
(default in template: `\sffamily\smaller`)