### PR TITLE
Add any option to axis

### DIFF
--- a/artist/multi_plot.py
+++ b/artist/multi_plot.py
@@ -55,6 +55,7 @@ class MultiPlot(BasePlotContainer):
         self.colorbar = None
         self.colormap = None
         self.external_filename = None
+        self.axis_options = None
 
         self.subplots = []
         for i in range(rows):
@@ -459,6 +460,7 @@ class MultiPlot(BasePlotContainer):
                                    colorbar=self.colorbar,
                                    colormap=self.colormap,
                                    external_filename=self.external_filename,
+                                   axis_options=self.axis_options,
                                    subplots=self.subplots,
                                    plot_template=self.template)
         return response
@@ -543,6 +545,27 @@ class MultiPlot(BasePlotContainer):
 
         """
         self.colormap = name
+
+    def set_axis_options(self, row, column, text):
+        """Set additionnal options as plain text."""
+
+        subplot = self.get_subplot_at(row, column)
+        subplot.set_axis_options(text)
+
+    def set_axis_options_for_all(self, row_column_list=None, text=''):
+        """Set point size limits of specified subplots.
+
+        :param row_column_list: a list containing (row, column) tuples to
+            specify the subplots, or None to indicate *all* subplots.
+        :type row_column_list: list or None
+        :param text: axis options for the given subplots or the overall plot.
+
+        """
+        if row_column_list is None:
+            self.axis_options = text
+        else:
+            for row, column in row_column_list:
+                self.set_axis_options(row, column, text)
 
 
 class SubPlotContainer(SubPlot):

--- a/artist/plot.py
+++ b/artist/plot.py
@@ -111,7 +111,8 @@ class BasePlotContainer(object):
 
         """
         self.save_assets(dest_path)
-        self.external_filename = 'externalized-' + os.path.basename(dest_path)
+        self.external_filename = 'externalized-%s' % \
+                                 os.path.basename(dest_path).replace(' ', '_')
         dest_path = self._add_extension('tex', dest_path)
         with open(dest_path, 'w') as f:
             f.write(self.render())
@@ -123,7 +124,8 @@ class BasePlotContainer(object):
 
         """
         self.save_assets(dest_path)
-        self.external_filename = 'externalized-' + os.path.basename(dest_path)
+        self.external_filename = 'externalized-%s' % \
+                                 os.path.basename(dest_path).replace(' ', '_')
         dest_path = self._add_extension('tex', dest_path)
         with open(dest_path, 'w') as f:
             f.write(self.render_as_document())

--- a/artist/templates/multi_plot.tex
+++ b/artist/templates/multi_plot.tex
@@ -71,6 +71,9 @@
                             rgb255(7cm)=(222, 96, 77);
                             rgb255(8cm)=(180,  4, 38)},
                     {%- endif %}
+                    {%- if axis_options %}
+                        {{ axis_options }}
+                    {%- endif %}
                 ]
                 {% for subplot in subplots %}
                     {% set plot = subplot %}
@@ -178,6 +181,9 @@
                         {%- endif %}
                         {%- if subplot.limits.mmax is not none %}
                             point meta max={ {{ subplot.limits.mmax }} },
+                        {%- endif %}
+                        {%- if subplot.axis_options %}
+                            {{ subplot.axis_options }}
                         {%- endif %}
                     {%- endif %}
                     ]

--- a/artist/templates/multi_plot.tex
+++ b/artist/templates/multi_plot.tex
@@ -8,7 +8,7 @@
 % \usepackage{relsize}
 %
 {%- if external_filename %}
-    \tikzsetnextfilename{ {{ external_filename }} }
+    \tikzsetnextfilename{ {{- external_filename -}} }
 {%- endif %}
 \pgfkeysifdefined{/artist/width}
     {\pgfkeysgetvalue{/artist/width}{\defaultwidth}}

--- a/artist/templates/plot.tex
+++ b/artist/templates/plot.tex
@@ -8,7 +8,7 @@
 % \usepackage{relsize}
 %
 {%- if external_filename %}
-    \tikzsetnextfilename{ {{ external_filename }} }
+    \tikzsetnextfilename{ {{- external_filename -}} }
 {%- endif %}
 \pgfkeysifdefined{/artist/width}
     {\pgfkeysgetvalue{/artist/width}{\defaultwidth}}

--- a/artist/templates/polar_plot.tex
+++ b/artist/templates/polar_plot.tex
@@ -9,7 +9,7 @@
 % \usepackage{relsize}
 %
 {%- if external_filename %}
-    \tikzsetnextfilename{ {{ external_filename }} }
+    \tikzsetnextfilename{ {{- external_filename -}} }
 {%- endif %}
 \pgfkeysifdefined{/artist/width}
     {\pgfkeysgetvalue{/artist/width}{\defaultwidth}}

--- a/artist/templates/polar_plot.tex
+++ b/artist/templates/polar_plot.tex
@@ -75,6 +75,8 @@
             {%- if ticks.ysuffix %}
                 yticklabel=$\pgfmathprintnumber{\tick}{{ ticks.ysuffix }}$,
             {%- endif %}
+            xticklabel style={ {{ ticks.xlabel_style }} },
+            yticklabel style={ {{ ticks.ylabel_style }} },
             yticklabel shift={\ytickshift},
             xticklabel shift={0.075cm},
             %
@@ -83,6 +85,9 @@
             max space between ticks=40,
             every tick/.style={},
             axis on top,
+            {%- if axis_options %}
+                {{ axis_options }}
+            {%- endif %}
         ]
 
         % hack to calculate the position for the xlabel

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,3 +1,5 @@
+.PHONY: clean
+
 all: demo
 
 demo: demo_plots.pdf

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -25,6 +25,7 @@ distclean: clean
 	rm -f relative_pin.tex
 	rm -f relative_pin_log.tex
 	rm -f any_option.tex
+	rm -f multi_any_option.tex
 	rm -f *.pdf
 	rm -f *.png
 
@@ -34,14 +35,16 @@ demo_plots.pdf: demo_plots.tex \
 		spectrum.tex sciencepark.tex utrecht.tex multiplot.tex \
 		polar_histogram.tex discrete_directions.tex histogram2d.tex \
 		multi_histogram2d.tex event_display.tex multi_event_display.tex \
-		relative_pin.tex relative_pin_log.tex any_option.tex
+		relative_pin.tex relative_pin_log.tex any_option.tex \
+		multi_any_option.tex
 	latexmk -pdf demo_plots.tex
 
 test: shower-front.tex eas-lateral.tex \
 		spectrum.tex sciencepark.tex utrecht.tex multiplot.tex \
 		polar_histogram.tex discrete_directions.tex histogram2d.tex \
 		multi_histogram2d.tex event_display.tex multi_event_display.tex \
-		relative_pin.tex relative_pin_log.tex any_option.tex
+		relative_pin.tex relative_pin_log.tex any_option.tex \
+		multi_any_option.tex
 
 stopping-power-mpl.pdf stopping-power.tex: demo_stopping_power.py
 	python $?
@@ -82,5 +85,5 @@ event_display.tex multi_event_display.tex: demo_event_display.py
 relative_pin.tex relative_pin_log.tex: demo_relative_pin.py
 	python $?
 
-any_option.tex: demo_any_option.py
+any_option.tex multi_any_option.tex: demo_any_option.py
 	python $?

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -22,6 +22,7 @@ distclean: clean
 	rm -f multi_event_display.tex
 	rm -f relative_pin.tex
 	rm -f relative_pin_log.tex
+	rm -f any_option.tex
 	rm -f *.pdf
 	rm -f *.png
 
@@ -31,14 +32,14 @@ demo_plots.pdf: demo_plots.tex \
 		spectrum.tex sciencepark.tex utrecht.tex multiplot.tex \
 		polar_histogram.tex discrete_directions.tex histogram2d.tex \
 		multi_histogram2d.tex event_display.tex multi_event_display.tex \
-		relative_pin.tex relative_pin_log.tex
+		relative_pin.tex relative_pin_log.tex any_option.tex
 	latexmk -pdf demo_plots.tex
 
 test: shower-front.tex eas-lateral.tex \
 		spectrum.tex sciencepark.tex utrecht.tex multiplot.tex \
 		polar_histogram.tex discrete_directions.tex histogram2d.tex \
 		multi_histogram2d.tex event_display.tex multi_event_display.tex \
-		relative_pin.tex relative_pin_log.tex
+		relative_pin.tex relative_pin_log.tex any_option.tex
 
 stopping-power-mpl.pdf stopping-power.tex: demo_stopping_power.py
 	python $?
@@ -77,4 +78,7 @@ event_display.tex multi_event_display.tex: demo_event_display.py
 	python $?
 
 relative_pin.tex relative_pin_log.tex: demo_relative_pin.py
+	python $?
+
+any_option.tex: demo_any_option.py
 	python $?

--- a/demo/demo_any_option.py
+++ b/demo/demo_any_option.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from artist import Plot
+
+
+def main():
+    x = np.arange(10)
+    y = (x / 2.) - 3.
+    colors = ['black', 'red', 'blue', 'yellow', 'purple']
+    plot = Plot()
+
+    for i in range(5):
+        plot.plot(x, y - i, mark='', linestyle=colors[i])
+
+    plot.set_axis_options('yticklabel pos=right,\n'
+                          'grid=major,\n'
+                          'legend entries={$a$,[red]$b$,[green]$c$,$d$,$a^2$},\n'
+                          'legend pos=north west')
+
+    plot.set_xlabel('Something important')
+    plot.set_ylabel('A related thing')
+    plot.save('any_option')
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/demo_any_option.py
+++ b/demo/demo_any_option.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from artist import Plot
+from artist import Plot, MultiPlot
 
 
 def main():
@@ -20,6 +20,26 @@ def main():
     plot.set_xlabel('Something important')
     plot.set_ylabel('A related thing')
     plot.save('any_option')
+
+    x = np.linspace(.6 * np.pi, 10 * np.pi, 150)
+    y = np.sin(x) / x
+    plot = MultiPlot(1, 2, width=r'.4\linewidth', height=r'.25\linewidth')
+
+    subplot = plot.get_subplot_at(0, 0)
+    subplot.plot(x, y, mark=None)
+
+    subplot = plot.get_subplot_at(0, 1)
+    subplot.plot(x, y, mark=None)
+
+    plot.show_xticklabels_for_all([(0, 0), (0, 1)])
+    plot.show_yticklabels(0, 1)
+    plot.set_axis_options(0, 1, 'yticklabel pos=right, grid=major')
+
+    plot.set_axis_options_for_all(None, r'enlargelimits=false')
+
+    plot.set_xlabel('Something important')
+    plot.set_ylabel('A related thing')
+    plot.save('multi_any_option')
 
 
 if __name__ == '__main__':

--- a/demo/demo_plots.tex
+++ b/demo/demo_plots.tex
@@ -146,4 +146,11 @@ detector. The color is based on the arrival time of the particles.}
          the relative position.}
 \end{figure}
 
+\begin{figure}
+\centering
+\input{any_option}
+\caption{This shows that any other pgfplots option like legends and
+         grids can be enabled manually.}
+\end{figure}
+
 \end{document}

--- a/demo/demo_plots.tex
+++ b/demo/demo_plots.tex
@@ -153,4 +153,12 @@ detector. The color is based on the arrival time of the particles.}
          grids can be enabled manually.}
 \end{figure}
 
+\begin{figure}
+\centering
+\input{multi_any_option}
+\caption{This shows that pgfplots axis option like grids and automatic
+         limit enlargement can be set manually for individual subplots
+         and globally for all subplots.}
+\end{figure}
+
 \end{document}


### PR DESCRIPTION
Adds set_axis_options to plots.
This can be used to set any not-directly-by-artist-supported option for an axis.

Todo:
- [x] Check support for
    - [x] multiplot.
    - [x] polarplot
- [x] Test it
- [x] Demo
- [x] Fix externalize filenames