### PR TITLE
Apply series options to corresponding errors

### DIFF
--- a/artist/templates/subplot.tex
+++ b/artist/templates/subplot.tex
@@ -66,15 +66,17 @@
     {% if series.show_xerr %}
         % Draw x-error bars
         {%- for x, y, xerr, yerr in series.data %}
-            \draw (axis cs:{{ x - xerr }}, {{ y }}) --
-                  (axis cs:{{ x + xerr }}, {{ y }});
+            \draw[{{ series.options }}]
+                 (axis cs:{{ x - xerr }}, {{ y }}) --
+                 (axis cs:{{ x + xerr }}, {{ y }});
         {%- endfor %}
     {%- endif %}
     {%- if series.show_yerr %}
         % Draw y-error bars
         {%- for x, y, xerr, yerr in series.data %}
-            \draw (axis cs:{{ x }}, {{ y - yerr }}) --
-                  (axis cs:{{ x }}, {{ y + yerr }});
+            \draw[{{ series.options }}]
+                 (axis cs:{{ x }}, {{ y - yerr }}) --
+                 (axis cs:{{ x }}, {{ y + yerr }});
         {%- endfor %}
     {% endif %}
     % Draw series plot


### PR DESCRIPTION
Give error bars the same style as series data.

This at least gives them the same color, but may cause problems if you use for instance dashed lines..

Please review carefully before merging.
